### PR TITLE
Move serde .resolve method to Hocon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hocon"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["François Mockers <mockersf@gmail.com>"]
 edition = "2018"
 description = "Reads HOCON configuration files"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,11 +467,7 @@ impl HoconLoader {
     where
         T: ::serde::Deserialize<'de>,
     {
-        Ok(
-            crate::serde::from_hocon(self.hocon()?).map_err(|err| Error::Deserialization {
-                message: err.message,
-            })?,
-        )
+        self.hocon()?.resolve()
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -528,6 +528,35 @@ impl Hocon {
     }
 }
 
+impl Hocon {
+    /// Deserialize the loaded documents to the target type
+    ///
+    /// # Errors
+    ///
+    /// * [`Error::Deserialization`](enum.Error.html#variant.Deserialization) if there was a
+    /// serde error during deserialization (missing required field, type issue, ...)
+    ///
+    /// # Additional errors in strict mode
+    ///
+    /// * [`Error::Include`](enum.Error.html#variant.Include) if there was an issue with an
+    /// included file
+    /// * [`Error::KeyNotFound`](enum.Error.html#variant.KeyNotFound) if there is a substitution
+    /// with a key that is not present in the document
+    /// * [`Error::DisabledExternalUrl`](enum.Error.html#variant.DisabledExternalUrl) if crate
+    /// was built without feature `url-support` and an `include url("...")` was found
+    #[cfg(feature = "serde-support")]
+    pub fn resolve<'de, T>(self) -> Result<T, crate::Error>
+        where
+            T: ::serde::Deserialize<'de>,
+    {
+        Ok(
+            crate::serde::from_hocon(self).map_err(|err| crate::Error::Deserialization {
+                message: err.message,
+            })?,
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Its give flexibility to parse complex Hocon files that is not possible
to defined as a single structure.