### PR TITLE
Allow escaped double quotes inside string values

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,7 +80,7 @@ named!(
     delimited!(
         char!('"'),
         map_res!(
-            escaped!(none_of!("\"\n"), '\\', one_of!("\"n\\")),
+            escaped!(none_of!("\\\"\n"), '\\', one_of!("\"n\\")),
             str::from_utf8
         ),
         char!('"')

--- a/tests/parse.rs
+++ b/tests/parse.rs
@@ -17,6 +17,17 @@ fn parse_string() {
 }
 
 #[test]
+fn parse_string_escaped() {
+    let s = r#"{"a":"dn\"d\"jf"}"#;
+    let doc: Hocon = dbg!(HoconLoader::new().load_str(dbg!(s)))
+        .expect("during test")
+        .hocon()
+        .expect("during test");
+
+    assert_eq!(doc["a"].as_string().expect("during test"), "dn\\\"d\\\"jf");
+}
+
+#[test]
 fn parse_string_strict_with_windows_newline() {
     let s = "{\"a\":\r\n\"dndjf\"\r\n}\r\n";
     let doc: Hocon = dbg!(HoconLoader::new().strict().load_str(dbg!(s)))


### PR DESCRIPTION
Consider, for example, a config for a CSV parser of some sort. It could look something like the following:
```hocon
{
delimiter: ","
quote: "\""
}
```

Arguably, one may want to translate escaped characters automatically. And there is even a macro for this `escaped_transform`. But, firstly, this will change type signatures quite a lot. And secondly - I do not need the automatic escaping , in my use case =]