### PR TITLE
Use "thiserror" in favor of "failure"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Cargo.lock
 .DS_Store
 
 tmp
+
+/**/.idea
+*.iml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ readme = "README.md"
 travis-ci = { repository = "mockersf/hocon.rs" }
 
 [dependencies]
+thiserror = "1.0.*"
 nom = "4.2"
 serde = { version = "1.0", optional = true }
 java-properties = "1.3"
 memchr = "2.3"
 reqwest = { version = "0.11", optional = true, features = [ "blocking" ] }
-failure = "0.1"
 uuid = { version = "0.8", features = [ "v4" ] }
 serde_path_to_error = "0.1"
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ struct Configuration {
     auto_connect: bool,
 }
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), Error> {
     let s = r#"{
         host: 127.0.0.1
         port: 80
@@ -41,7 +41,7 @@ fn main() -> Result<(), failure::Error> {
 ```rust
 use hocon::HoconLoader;
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), Error> {
     let s = r#"{ a: 7 }"#;
 
     let doc = HoconLoader::new()
@@ -69,7 +69,7 @@ struct Configuration {
     auto_connect: bool,
 }
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), Error> {
     let s = r#"{
         host: 127.0.0.1
         port: 80
@@ -89,7 +89,7 @@ fn main() -> Result<(), failure::Error> {
 ```rust
 use hocon::HoconLoader;
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), Error> {
     let doc = HoconLoader::new()
         .load_file("tests/data/basic.conf")?
         .hocon()?;
@@ -106,7 +106,7 @@ fn main() -> Result<(), failure::Error> {
 ```rust
 use hocon::HoconLoader;
 
-fn main() -> Result<(), failure::Error> {
+fn main() -> Result<(), Error> {
     let s = r#"{
         a: will be changed
         unchanged: original value
@@ -153,7 +153,7 @@ struct Configuration {
     auto_connect: bool,
 }
 
-# fn main() -> Result<(), failure::Error> {
+# fn main() -> Result<(), Error> {
 let s = r#"{host: 127.0.0.1, port: 80, auto_connect: false}"#;
 
 # #[cfg(feature = "serde-support")]

--- a/examples/hocon2json.rs
+++ b/examples/hocon2json.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use serde_json::{Number, Value};
 
-use hocon::{Hocon, HoconLoader};
+use hocon::{Error, Hocon, HoconLoader};
 
 fn hocon_to_json(hocon: Hocon) -> Option<Value> {
     match hocon {
@@ -29,10 +29,14 @@ fn hocon_to_json(hocon: Hocon) -> Option<Value> {
     }
 }
 
-fn parse_to_json(path: &str) -> Result<String, failure::Error> {
+fn parse_to_json(path: &str) -> Result<String, Error> {
     let hocon = dbg!(HoconLoader::new().no_system().load_file(path)?.hocon())?;
     let json: Option<_> = hocon_to_json(hocon);
-    Ok(serde_json::to_string_pretty(&json)?)
+    Ok(
+        serde_json::to_string_pretty(&json).map_err(|e| Error::Deserialization {
+            message: e.to_string(),
+        })?,
+    )
 }
 
 fn main() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,63 +1,64 @@
-use std::error::Error as StdError;
-
-impl StdError for Error {}
-use std::fmt;
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Error::File { path } => write!(f, "Error reading file '{}'", path),
-            Error::Parse => write!(f, "Error wile parsing document"),
-            Error::Include { path } => write!(f, "Error including document at '{}'", path),
-            Error::TooManyIncludes => write!(f, "Error processing deep includes"),
-            Error::IncludeNotAllowedFromStr => {
-                write!(f, "Error processing includes from a str source")
-            }
-            Error::DisabledExternalUrl => write!(
-                f,
-                "Error including document with External URL as feature has been disabled"
-            ),
-            Error::KeyNotFound { key } => write!(f, "Error looking for key '{}'", key),
-            Error::MissingKey => write!(f, "Error getting a value because key is not present"),
-            Error::InvalidKey => write!(f, "Error getting a value because of an invalid key type"),
-            Error::Deserialization { message } => write!(f, "Error deserializing: {}", message),
-        }
-    }
-}
+use thiserror::Error;
 
 /// Errors that can be encountered while reading a HOCON document
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Error, Debug, Clone, PartialEq)]
 pub enum Error {
+    /// Captures IO-Errors. Usually we would use a transparent error but io::Error is not clonable
+    #[error("Error during IO")]
+    IO {
+        /// the description of the original IOError
+        message: String,
+    },
+
     /// Error reading a file. This can be a file not found, a permission issue, ...
+    #[error("Error reading file '{path:?}'")]
     File {
         /// Path to the file being read
         path: String,
     },
     /// Error while parsing a document. The document is not valid HOCON
+    #[error("Error wile parsing document")]
     Parse,
     /// Error including a document
+    #[error("Error including document at '{path:?}'")]
     Include {
         /// Path of the included file
         path: String,
     },
     /// Error processing deep includes. You can change the maximum depth using max_include_depth
+    #[error("Error processing deep includes")]
     TooManyIncludes,
     /// Error processing includes from a str source. This is not allowed
+    #[error("Error processing includes from a str source")]
     IncludeNotAllowedFromStr,
     /// Error including document with External URL as feature has been disabled
+    #[error("Error including document with External URL as feature has been disabled")]
     DisabledExternalUrl,
     /// Error looking for a key
+    #[error("Error looking for key '{key:?}'")]
     KeyNotFound {
         /// Key that was searched
         key: String,
     },
     /// Error getting a value because key is not present
+    #[error("Error getting a value because key is not present")]
     MissingKey,
     /// Error getting a value because of an invalid key type
+    #[error("Error getting a value because of an invalid key type")]
     InvalidKey,
     /// Error deserializing
+    #[error("Error deserializing: {message:?}")]
     Deserialization {
         /// Error message returned from deserialization
         message: String,
     },
+}
+
+/// this is only needed because this crate heavily relies on Clone and io:Error doesnt implement Clone
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::IO {
+            message: e.to_string(),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 //!
 //! ```rust
 //! use serde::Deserialize;
+//! use hocon::Error;
 //!
 //! #[derive(Deserialize)]
 //! struct Configuration {
@@ -35,7 +36,7 @@
 //!     auto_connect: bool,
 //! }
 //!
-//! # fn main() -> Result<(), failure::Error> {
+//! # fn main() -> Result<(), Error> {
 //! let s = r#"{
 //!     host: 127.0.0.1
 //!     port: 80
@@ -52,9 +53,9 @@
 //! ## Reading from a string and getting value directly
 //!
 //! ```rust
-//! use hocon::HoconLoader;
+//! use hocon::{HoconLoader,Error};
 //!
-//! # fn main() -> Result<(), failure::Error> {
+//! # fn main() -> Result<(), Error> {
 //! let s = r#"{ a: 7 }"#;
 //!
 //! let doc = HoconLoader::new()
@@ -72,7 +73,7 @@
 //! ```rust
 //! use serde::Deserialize;
 //!
-//! use hocon::HoconLoader;
+//! use hocon::{HoconLoader,Error};
 //!
 //! #[derive(Deserialize)]
 //! struct Configuration {
@@ -81,7 +82,7 @@
 //!     auto_connect: bool,
 //! }
 //!
-//! # fn main() -> Result<(), failure::Error> {
+//! # fn main() -> Result<(), Error> {
 //! let s = r#"{
 //!     host: 127.0.0.1
 //!     port: 80
@@ -102,9 +103,9 @@
 //! [tests/data/basic.conf](https://raw.githubusercontent.com/mockersf/hocon.rs/master/tests/data/basic.conf)
 //!
 //! ```rust
-//! use hocon::HoconLoader;
+//! use hocon::{HoconLoader,Error};
 //!
-//! # fn main() -> Result<(), failure::Error> {
+//! # fn main() -> Result<(), Error> {
 //! let doc = HoconLoader::new()
 //!     .load_file("tests/data/basic.conf")?
 //!     .hocon()?;
@@ -121,9 +122,9 @@
 //! [tests/data/basic.conf](https://raw.githubusercontent.com/mockersf/hocon.rs/master/tests/data/basic.conf)
 //!
 //! ```rust
-//! use hocon::HoconLoader;
+//! use hocon::{HoconLoader,Error};
 //!
-//! # fn main() -> Result<(), failure::Error> {
+//! # fn main() -> Result<(), Error> {
 //! let s = r#"{
 //!     a: will be changed
 //!     unchanged: original value
@@ -160,7 +161,7 @@
 //! ```rust
 //! use serde::Deserialize;
 //!
-//! use hocon::HoconLoader;
+//! use hocon::{HoconLoader,Error};
 //!
 //! #[derive(Deserialize)]
 //! struct Configuration {
@@ -169,7 +170,7 @@
 //!     auto_connect: bool,
 //! }
 //!
-//! # fn main() -> Result<(), failure::Error> {
+//! # fn main() -> Result<(), Error> {
 //! let s = r#"{host: 127.0.0.1, port: 80, auto_connect: false}"#;
 //!
 //! # #[cfg(feature = "serde-support")]
@@ -208,8 +209,8 @@ pub use crate::serde::de;
 /// # Usage
 ///
 /// ```rust
-/// # use hocon::HoconLoader;
-/// # fn main() -> Result<(), failure::Error> {
+/// # use hocon::{HoconLoader,Error};
+/// # fn main() -> Result<(), Error> {
 /// # #[cfg(not(feature = "url-support"))]
 /// # let mut loader = HoconLoader::new()         // Creating new loader with default configuration
 /// #     .no_system();                           // Disable substituting from system environment
@@ -264,8 +265,8 @@ impl HoconLoader {
     ///
     /// with system:
     /// ```rust
-    /// # use hocon::{Hocon, HoconLoader};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # use hocon::{Hocon, HoconLoader, Error};
+    /// # fn main() -> Result<(), Error> {
     /// # std::env::set_var("SHELL", "/bin/bash");
     /// # let example = r#"{system.shell: ${SHELL}}"#;
     /// assert_eq!(
@@ -279,7 +280,7 @@ impl HoconLoader {
     /// without system:
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// # let example = r#"{system.shell: ${SHELL}}"#;
     /// assert_eq!(
     ///     HoconLoader::new().no_system().load_str(example)?.hocon()?["system"]["shell"],
@@ -308,8 +309,8 @@ impl HoconLoader {
     ///
     /// with url include:
     /// ```rust
-    /// # use hocon::{Hocon, HoconLoader};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # use hocon::{Hocon, HoconLoader, Error};
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_file("tests/data/include_url.conf")?.hocon()?["d"],
     ///     Hocon::Boolean(true)
@@ -321,7 +322,7 @@ impl HoconLoader {
     /// without url include:
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().no_url_include().load_file("tests/data/include_url.conf")?.hocon()?["d"],
     ///     Hocon::BadValue(Error::MissingKey)
@@ -359,7 +360,7 @@ impl HoconLoader {
     /// in permissive mode:
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// # let example = r#"{ a = ${b} }"#;
     /// assert_eq!(
     ///     HoconLoader::new().load_str(example)?.hocon()?["a"],
@@ -372,7 +373,7 @@ impl HoconLoader {
     /// in strict mode:
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// # let example = r#"{ a = ${b} }"#;
     /// assert_eq!(
     ///     HoconLoader::new().strict().load_str(example)?.hocon(),
@@ -452,11 +453,14 @@ impl HoconLoader {
             file_path = current_path;
         }
         let conf = self.config.with_file(file_path);
-        let contents = conf.read_file().map_err(|err| Error::File {
-            path: String::from(
-                err.name()
-                    .unwrap_or_else(|| path.as_ref().to_str().unwrap_or("invalid path")),
-            ),
+        let contents = conf.read_file().map_err(|err| {
+            let path = match err {
+                Error::File { path } => path,
+                Error::Include { path } => path,
+                Error::IO { message } => message,
+                _ => "unmatched error".to_string(),
+            };
+            Error::File { path }
         })?;
         Self {
             config: conf,

--- a/src/loader_config.rs
+++ b/src/loader_config.rs
@@ -1,3 +1,4 @@
+use crate::Error;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::prelude::*;
@@ -117,7 +118,7 @@ impl HoconLoaderConfig {
     pub(crate) fn parse_str_to_internal(
         &self,
         s: FileRead,
-    ) -> Result<crate::internals::HoconInternal, crate::Error> {
+    ) -> Result<crate::internals::HoconInternal, Error> {
         let mut internal = crate::internals::HoconInternal::empty();
         if let Some(properties) = s.properties {
             internal = internal.add(
@@ -176,14 +177,14 @@ impl HoconLoaderConfig {
             .unwrap_or(true)
     }
 
-    pub(crate) fn read_file_to_string(path: PathBuf) -> Result<String, failure::Error> {
+    pub(crate) fn read_file_to_string(path: PathBuf) -> Result<String, Error> {
         let mut file = File::open(path.as_os_str())?;
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
         Ok(contents)
     }
 
-    pub(crate) fn read_file(&self) -> Result<FileRead, failure::Error> {
+    pub(crate) fn read_file(&self) -> Result<FileRead, Error> {
         let full_path = self
             .file_meta
             .clone()
@@ -221,10 +222,7 @@ impl HoconLoaderConfig {
     }
 
     #[cfg(feature = "url-support")]
-    pub(crate) fn load_url(
-        &self,
-        url: &str,
-    ) -> Result<crate::internals::HoconInternal, failure::Error> {
+    pub(crate) fn load_url(&self, url: &str) -> Result<crate::internals::HoconInternal, Error> {
         if let Ok(parsed_url) = reqwest::Url::parse(url) {
             if parsed_url.scheme() == "file" {
                 if let Ok(path) = parsed_url.to_file_path() {
@@ -238,8 +236,7 @@ impl HoconLoaderConfig {
                 } else {
                     Err(crate::Error::Include {
                         path: String::from(url),
-                    }
-                    .into())
+                    })
                 }
             } else if self.external_url {
                 let body = reqwest::blocking::get(parsed_url)
@@ -255,14 +252,12 @@ impl HoconLoaderConfig {
             } else {
                 Err(crate::Error::Include {
                     path: String::from(url),
-                }
-                .into())
+                })
             }
         } else {
             Err(crate::Error::Include {
                 path: String::from(url),
-            }
-            .into())
+            })
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -30,7 +30,7 @@ use std::ops::Index;
 ///
 /// ```rust
 /// # use hocon::{HoconLoader, Error, Hocon};
-/// # fn main() -> Result<(), failure::Error> {
+/// # fn main() -> Result<(), Error> {
 /// // Accessing a value of the expected type
 /// assert_eq!(
 ///     HoconLoader::new().load_str(r#"{ a: 7 }"#)?.hocon()?["a"].as_i64(),
@@ -214,7 +214,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ size = 1.5KiB }"#)?.hocon()?["size"].as_bytes(),
     ///     Some(1536.0)
@@ -260,7 +260,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 hour  }"#)?
     ///         .hocon()?["duration"].as_milliseconds(),
@@ -300,7 +300,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 hour  }"#)?
     ///         .hocon()?["duration"].as_nanoseconds(),
@@ -323,7 +323,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 hour  }"#)?
     ///         .hocon()?["duration"].as_microseconds(),
@@ -346,7 +346,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 hour  }"#)?
     ///         .hocon()?["duration"].as_seconds(),
@@ -369,7 +369,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 hour  }"#)?
     ///         .hocon()?["duration"].as_minutes(),
@@ -393,7 +393,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 hour  }"#)?
     ///         .hocon()?["duration"].as_hours(),
@@ -417,7 +417,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 hour  }"#)?
     ///         .hocon()?["duration"].as_days(),
@@ -441,7 +441,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 days  }"#)?
     ///         .hocon()?["duration"].as_weeks(),
@@ -465,7 +465,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 days  }"#)?
     ///         .hocon()?["duration"].as_months(),
@@ -489,7 +489,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 days  }"#)?
     ///         .hocon()?["duration"].as_years(),
@@ -513,7 +513,7 @@ impl Hocon {
     ///
     /// ```rust
     /// # use hocon::{Hocon, HoconLoader, Error};
-    /// # fn main() -> Result<(), failure::Error> {
+    /// # fn main() -> Result<(), Error> {
     /// assert_eq!(
     ///     HoconLoader::new().load_str(r#"{ duration = 1.5 hours  }"#)?
     ///         .hocon()?["duration"].as_duration(),


### PR DESCRIPTION
Fixes  mockersf/hocon.rs#41

Instead of the deprecated "failure" crate this PR introduces "thiserror" which can derive Error which are all based upon std::error::Error and thus doesn't introduce a error-handling dependency for library users.

Messages have been mapped from the previous Display-impl to the corresponding macros.

Unfortunately it was not possible to use a transparent-error for std::io::Error because the crate heavily relies on Clone and std::io::Error does not implement Clone.
Hence an additional From<<std::io::Error>> impl has been added.