### PR TITLE
✨ can deserialize duration 

### DIFF
--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -3,6 +3,8 @@
 use super::error::{Error, Result};
 use crate::Hocon;
 
+pub use super::wrappers;
+
 macro_rules! impl_deserialize_n {
     ($method:ident, $visit:ident) => {
         fn $method<V>(self, visitor: V) -> Result<V::Value>

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -1,5 +1,7 @@
 pub mod de;
 
-mod error;
+pub mod wrappers;
+
+pub(crate) mod error;
 
 pub(crate) use de::from_hocon;

--- a/src/serde/wrappers.rs
+++ b/src/serde/wrappers.rs
@@ -1,0 +1,121 @@
+//! Wrapper for custom deserialization from Hocon
+
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+    time::Duration,
+};
+
+use serde::{
+    de::{self, Deserialize, Visitor},
+    Deserializer,
+};
+
+use crate::Hocon;
+
+/// Wrapper for custom deserialization from Hocon.
+///
+/// Implemented for [`Duration`]
+///
+/// ## As a newtype wrapper
+///
+/// ```rust
+/// # use std::time::Duration;
+/// # use hocon::de::wrappers::Serde;
+/// # use serde::Deserialize;
+/// #[derive(Deserialize, Debug)]
+/// struct StructWithDuration {
+///     timeout: Serde<Duration>,
+/// }
+/// # fn usage() {
+/// # let doc = r#"{"a":"1 second"}"#;
+///
+/// let my_struct: StructWithDuration = hocon::de::from_str(doc).unwrap();
+/// assert_eq!(*my_struct.timeout, Duration::from_secs(1));
+/// # }
+/// ```
+///
+/// ## As a serde attribute
+///
+/// ```rust
+/// # use std::time::Duration;
+/// # use hocon::de::wrappers::Serde;
+/// # use serde::Deserialize;
+/// #[derive(Deserialize, Debug)]
+/// struct StructWithDuration {
+///     #[serde(deserialize_with = "Serde::<Duration>::with")]
+///     timeout: Duration,
+/// }
+/// # fn usage() {
+/// # let doc = r#"{"a":"1 second"}"#;
+///
+/// let my_struct: StructWithDuration = hocon::de::from_str(doc).unwrap();
+/// assert_eq!(my_struct.timeout, Duration::from_secs(1));
+/// # }
+/// ```
+#[doc(alias = "Duration")]
+#[derive(Debug)]
+pub struct Serde<T>(T);
+
+impl<T> Deref for Serde<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Serde<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+struct StringDurationVisitor;
+
+impl<'de> Visitor<'de> for StringDurationVisitor {
+    type Value = Duration;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a duration")
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let duration = Hocon::str_as_milliseconds(&v)
+            .ok_or_else(|| E::custom(format!("expected duration, found \"{}\"", v)))?;
+
+        Ok(Duration::from_secs_f64(duration / 1000.0))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let duration = Hocon::str_as_milliseconds(v)
+            .ok_or_else(|| E::custom(format!("expected duration, found \"{}\"", v)))?;
+
+        Ok(Duration::from_secs_f64(duration / 1000.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for Serde<Duration> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Serde(deserializer.deserialize_str(StringDurationVisitor)?))
+    }
+}
+
+impl Serde<Duration> {
+    /// Custom deserializer for a duration, to use with Serde `deserialize_with` attribute
+    pub fn with<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(deserializer.deserialize_str(StringDurationVisitor)?)
+    }
+}

--- a/src/serde/wrappers.rs
+++ b/src/serde/wrappers.rs
@@ -116,6 +116,6 @@ impl Serde<Duration> {
     where
         D: Deserializer<'de>,
     {
-        Ok(deserializer.deserialize_str(StringDurationVisitor)?)
+        deserializer.deserialize_str(StringDurationVisitor)
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -273,21 +273,25 @@ impl Hocon {
         match *self {
             Hocon::Integer(ref i) => Some(*i as f64),
             Hocon::Real(ref f) => Some(*f),
-            Hocon::String(ref s) => units!(
-                match unit_format::value_and_unit(s).map(|(value, unit)| (value, unit.trim())),
-                "ns", "nano", "nanos", "nanosecond", "nanoseconds"          => 10.0f64.powf(-6.0),
-                "us", "micro", "micros", "microsecond", "microseconds"      => 10.0f64.powf(-3.0),
-                "", "ms", "milli", "millis", "millisecond", "milliseconds"  => 1.0,
-                "s", "second", "seconds"                                    => 1_000.0,
-                "m", "minute", "minutes"                                    => 1_000.0 * 60.0,
-                "h", "hour", "hours"                                        => 1_000.0 * 60.0 * 60.0,
-                "d", "day", "days"                                          => 1_000.0 * 60.0 * 60.0 * 24.0,
-                "w", "week", "weeks"                                        => 1_000.0 * 60.0 * 60.0 * 24.0 * 7.0,
-                "mo", "month", "months"                                     => 1_000.0 * 60.0 * 60.0 * 24.0 * 30.0,
-                "y", "year", "years"                                        => 1_000.0 * 60.0 * 60.0 * 24.0 * 365.0
-            ),
+            Hocon::String(ref s) => Self::str_as_milliseconds(s),
             _ => None,
         }
+    }
+
+    pub(crate) fn str_as_milliseconds(s: &str) -> Option<f64> {
+        units!(
+            match unit_format::value_and_unit(s).map(|(value, unit)| (value, unit.trim())),
+            "ns", "nano", "nanos", "nanosecond", "nanoseconds"          => 10.0f64.powf(-6.0),
+            "us", "micro", "micros", "microsecond", "microseconds"      => 10.0f64.powf(-3.0),
+            "", "ms", "milli", "millis", "millisecond", "milliseconds"  => 1.0,
+            "s", "second", "seconds"                                    => 1_000.0,
+            "m", "minute", "minutes"                                    => 1_000.0 * 60.0,
+            "h", "hour", "hours"                                        => 1_000.0 * 60.0 * 60.0,
+            "d", "day", "days"                                          => 1_000.0 * 60.0 * 60.0 * 24.0,
+            "w", "week", "weeks"                                        => 1_000.0 * 60.0 * 60.0 * 24.0 * 7.0,
+            "mo", "month", "months"                                     => 1_000.0 * 60.0 * 60.0 * 24.0 * 30.0,
+            "y", "year", "years"                                        => 1_000.0 * 60.0 * 60.0 * 24.0 * 365.0
+        )
     }
 
     /// Try to return a value as a duration in nanoseconds according to

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -104,3 +104,37 @@ fn deserialize_multilevel_struct_missing_field() {
         r#"Err(Deserialization { message: "i.ii: missing field `a`" })"#
     );
 }
+
+#[test]
+fn deserialize_struct_duration_wrapper() {
+    use hocon::de::wrappers::Serde;
+    use std::time::Duration;
+
+    #[derive(Deserialize, Debug)]
+    struct Test {
+        a: Serde<Duration>,
+    }
+
+    let s = r#"{"a":"1 second"}"#;
+
+    let doc: Test = dbg!(hocon::de::from_str(s)).expect("during test");
+
+    assert_eq!(*doc.a, std::time::Duration::from_secs(1));
+}
+
+#[test]
+fn deserialize_struct_duration_with() {
+    use hocon::de::wrappers::Serde;
+    use std::time::Duration;
+    #[derive(Deserialize, Debug)]
+    struct Test {
+        #[serde(deserialize_with = "Serde::<Duration>::with")]
+        a: std::time::Duration,
+    }
+
+    let s = r#"{"a":"1 second"}"#;
+
+    let doc: Test = dbg!(hocon::de::from_str(s)).expect("during test");
+
+    assert_eq!(doc.a, std::time::Duration::from_secs(1));
+}


### PR DESCRIPTION
adds two way to deserialize a `std::time::Duration`:
- a wrapper type
- a function to annotate the field with `deserialize_with`