### PR TITLE
Replacing native-tls with rustls in reqwest-dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ nom = "4.2"
 serde = { version = "1.0", optional = true }
 java-properties = "1.3"
 memchr = "2.3"
-reqwest = { version = "0.11", optional = true, features = [ "blocking" ] }
+reqwest = { version = "0.11", optional = true, default-features = false, features = [ "blocking", "rustls", "rustls-tls-native-roots" ] }
 uuid = { version = "0.8", features = [ "v4" ] }
 serde_path_to_error = "0.1"
 


### PR DESCRIPTION
Fixes #55

Result:
```
cargo tree -i -p native-tls      
error: package ID specification `native-tls` did not match any packages
```