### PR TITLE
Implement quoted string unescaping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ memchr = "2.3"
 reqwest = { version = "0.11", optional = true, default-features = false, features = [ "blocking", "rustls", "rustls-tls-native-roots" ] }
 uuid = { version = "0.8", features = [ "v4" ] }
 serde_path_to_error = "0.1"
+aho-corasick = "0.7.18"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 test-generator = "0.3"

--- a/src/internals/mod.rs
+++ b/src/internals/mod.rs
@@ -23,6 +23,9 @@ pub(crate) mod macros {
 
 mod intermediate;
 mod internal;
+mod str_unescape;
 mod value;
+
 pub(crate) use internal::*;
+pub(crate) use str_unescape::*;
 pub(crate) use value::*;

--- a/src/internals/str_unescape.rs
+++ b/src/internals/str_unescape.rs
@@ -1,0 +1,54 @@
+use aho_corasick::AhoCorasick;
+use lazy_static::lazy_static;
+use std::borrow::Cow;
+use std::ops::Range;
+
+/// Unescape a JSON string
+pub(crate) fn unescape(input: &str) -> Cow<str> {
+    const PATTERNS: &[&str] = &[
+        r#"\""#, r"\\", r"\/", r"\b", r"\f", r"\n", r"\r", r"\t", r"\u",
+    ];
+    const REPLACEMENTS: &[&str] = &["\"", "\\", "/", "\x08", "\x0c", "\x0a", "\x0d", "\x09"];
+    const HIGH_SURROGATES: Range<u16> = 0xd800..0xdc00;
+    const LOW_SURROGATES: Range<u16> = 0xdc00..0xe000;
+    lazy_static! {
+        static ref AC: AhoCorasick = AhoCorasick::new_auto_configured(PATTERNS);
+    }
+
+    let mut res = Cow::default();
+    let mut last_start: usize = 0;
+    let mut surrogates_vec: [u16; 2] = [0, 0];
+    for mat in AC.find_iter(input) {
+        res += &input[last_start..mat.start()];
+        last_start = mat.end();
+
+        if let Some(repl) = REPLACEMENTS.get(mat.pattern()) {
+            res += *repl;
+        } else if mat.end() + 4 <= input.len() {
+            // Handle \u
+            last_start += 4;
+            let hex_digits = &input[mat.end()..mat.end() + 4];
+            if let Ok(cp) = u16::from_str_radix(hex_digits, 16) {
+                // Handle Unicode surrogate pairs
+                if HIGH_SURROGATES.contains(&cp) {
+                    // Beginning of surrogate pair
+                    surrogates_vec[0] = cp;
+                } else {
+                    surrogates_vec[1] = cp;
+                    let surrogates_vec_ref = if LOW_SURROGATES.contains(&cp) {
+                        // Ending of surrogate pair, call: from_utf16([high, low])
+                        &surrogates_vec
+                    } else {
+                        // Not a surrogate pair, call: from_utf16([cp])
+                        &surrogates_vec[1..]
+                    };
+                    if let Ok(str) = String::from_utf16(surrogates_vec_ref) {
+                        res += Cow::from(str);
+                    }
+                }
+            }
+        }
+    }
+    res += &input[last_start..];
+    res
+}


### PR DESCRIPTION
Fixes: https://github.com/mockersf/hocon.rs/issues/53

Partially based on: https://github.com/changhe3/nom-json-parser/blob/cce34f560f394cdf1601ab9c5c2fd012eb405084/src/utils.rs#L73

Also, I'm not really familiar with nom so I'm not sure if [this](https://github.com/mockersf/hocon.rs/pull/60/files#diff-4a04259da480a6b794a2e947e4cc03eff4d1aa9330836f5b91cac68c5398193fR88) is the best place to hook in the unescape function. Maybe look over that if possible.

This PR also adds two dependencies but `hocon.rs` already depends on them transitively:
- **aho-corasick** - Previous transitive dependency chain: *hocon.rs* -> java-properties -> regex -> *aho-corasick*
- **lazy_static** - Previous transitive dependency chain: *hocon.rs* -> java-properties -> *lazy_static*